### PR TITLE
update guide to `2022.03.1` release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:edge
 
-ARG GITPOD_VERSION="2022.02.0"
+ARG GITPOD_VERSION="2022.03.1"
 
 RUN apk add --no-cache \
     bash \

--- a/setup.sh
+++ b/setup.sh
@@ -222,6 +222,11 @@ EOF
         render \
         --config="${CONFIG_FILE}" > gitpod.yaml
 
+    # See https://github.com/gitpod-io/gitpod/tree/main/install/installer#error-validating-statefulsetstatus
+    yq eval-all --inplace \
+        'del(select(.kind == "StatefulSet" and .metadata.name == "openvsx-proxy").status)' \
+        gitpod.yaml
+
     kubectl apply -f gitpod.yaml
 
     # remove shiftfs-module-loader container.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This release updates the guide to use `2022.03.1` release, while also
fixing the guide w.r.t status post processing block https://github.com/gitpod-io/gitpod-gke-guide/commit/a6d4b8d022ad80f571789189a81c6363a09b70a6

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
