### PR TITLE
Switch installation guide to use kots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:edge
 
-ARG GITPOD_VERSION="2022.03.1"
-
 RUN apk add --no-cache \
     bash \
     curl \
@@ -28,9 +26,6 @@ RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/$(curl
 
 RUN curl -fsSL https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.3/aws-iam-authenticator_0.5.3_linux_amd64 -o /usr/local/bin/aws-iam-authenticator \
   && chmod +x /usr/local/bin/aws-iam-authenticator
-
-RUN curl -fsSL https://github.com/gitpod-io/gitpod/releases/download/${GITPOD_VERSION}/gitpod-installer-linux-amd64 -o /usr/local/bin/gitpod-installer \
-  && chmod +x /usr/local/bin/gitpod-installer
 
 WORKDIR /gitpod
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
 endif
 
 build: ## Build docker image containing the required tools for the installation
-	@docker build --quiet . -t ${IMG}
+	@docker build . -t ${IMG}
 	@mkdir -p ${PWD}/logs
 
 DOCKER_RUN_CMD = docker run -it \

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Running Gitpod in [Amazon EKS](https://aws.amazon.com/en/eks/)
 
-> **IMPORTANT** This guide exists as a simple and reliable way of creating a Gitpod instance in Amazon EKS. It
+> **IMPORTANT** This guide exists as a simple and reliable way of creating required AWS infrastructure. It
 > is not designed to cater for every situation. If you find that it does not meet your exact needs,
 > please fork this guide and amend it to your own needs.
+
+This guide exists as a simple and reliable way of creating an environment in AWS (EKS) that [Gitpod can
+be installed](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) into.
 
 ## Provision an EKS cluster
 
@@ -70,50 +73,6 @@ The whole process takes around forty minutes. In the end, the following resource
 - [gitpod.io](https://github.com/gitpod-io/gitpod) deployment
 - A public DNS zone managed by Route53 (if `ROUTE53_ZONEID` env variable is configured)
 
-## Verify the installation
-
-First, check that Gitpod components are running.
-
-```shell
-kubectl get pods
-NAME                               READY   STATUS    RESTARTS   AGE
-blobserve-6bdb9c7f89-lvhxd         2/2     Running   0          6m17s
-content-service-59bd58bc4d-xgv48   1/1     Running   0          6m17s
-dashboard-6ffdf8984-b6f7j          1/1     Running   0          6m17s
-image-builder-5df5694848-wsdvk     3/3     Running   0          6m16s
-jaeger-8679bf6676-zz57m            1/1     Running   0          4h28m
-messagebus-0                       1/1     Running   0          4h11m
-proxy-56c4cdd799-bbfbx             1/1     Running   0          5m33s
-registry-6b75f99844-bhhqd          1/1     Running   0          4h11m
-registry-facade-f7twj              2/2     Running   0          6m12s
-server-64f9cf6b9b-bllgg            2/2     Running   0          6m16s
-ws-daemon-bh6h6                    2/2     Running   0          2m47s
-ws-manager-5d57746845-t74n5        2/2     Running   0          6m16s
-ws-manager-bridge-79f7fcb5-7w4p5   1/1     Running   0          6m16s
-ws-proxy-7fc9665-rchr9             1/1     Running   0          5m57s
-```
-
-TODO: add additional `kubectl log` commands
-
-### Test Gitpod workspaces
-
-When the provisioning and configuration of the cluster is done, the script shows the URL of the load balancer,
-like:
-
-```shell
-Load balancer hostname: k8s-default-gitpod-.......elb.amazonaws.com
-```
-
-This is the value of the `CNAME` field that needs to be configured in the DNS domain, for the record `<domain>`, `*.ws.<domain>` and `*.<domain>`
-
-After these three records are configured, please open the URL `https://<domain>/workspaces`.
-It should display the gitpod login page similar to the next image.
-
-> If the property `ROUTE53_ZONEID` is enabled in the .env file, we install [external-dns](https://github.com/kubernetes-sigs/external-dns) and such update is not required
-
-![Gitpod login page](./images/gitpod-login.png "Gitpod Login Page")
-
-----
 
 ## Update Gitpod auth providers
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the guide to remove the usage of installer
to Kots. :tada:

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Switch EKS guide from installer to kots
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
