### PR TITLE
Remove gitpod.io from created components and hint at the fact that the script generates files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > please fork this guide and amend it to your own needs.
 
 This guide exists as a simple and reliable way of creating an environment in AWS (EKS) that [Gitpod can
-be installed](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) into. Upon completion, it will print the config for the resources created (including passwords) and create the necessary credential files that will allow you to connect the components created to your gitpod instance during the [next installtion step](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod).
+be installed](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) into. Upon completion, it will print the config for the resources created (including passwords) and create the necessary credential files that will allow you to connect the components created to your Gitpod instance during the [next installation step](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod).
 
 ## Provision an EKS cluster
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > please fork this guide and amend it to your own needs.
 
 This guide exists as a simple and reliable way of creating an environment in AWS (EKS) that [Gitpod can
-be installed](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) into.
+be installed](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) into. It will generate a detailed text output and create credential files that together help you connect the created components to your Gitpod instance when you [proceed with your installation](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod).
 
 ## Provision an EKS cluster
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ The whole process takes around forty minutes. In the end, the following resource
 - [cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler)
 - [Jaeger operator](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator) - and Jaeger deployment for gitpod distributed tracing
 - [metrics-server](https://github.com/kubernetes-sigs/metrics-server)
-- [gitpod.io](https://github.com/gitpod-io/gitpod) deployment
 - A public DNS zone managed by Route53 (if `ROUTE53_ZONEID` env variable is configured)
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > please fork this guide and amend it to your own needs.
 
 This guide exists as a simple and reliable way of creating an environment in AWS (EKS) that [Gitpod can
-be installed](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) into. It will generate a detailed text output and create credential files that together help you connect the created components to your Gitpod instance when you [proceed with your installation](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod).
+be installed](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) into. Upon completion, it will print the config for the resources created (including passwords) and create the necessary credential files that will allow you to connect the components created to your gitpod instance during the [next installtion step](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod).
 
 ## Provision an EKS cluster
 


### PR DESCRIPTION
## Description
- Remove gitpod.io from the list of created components.
- Add a line in the readme to make it clear what the script produces

## Related Issue(s)

[#9821](https://github.com/gitpod-io/gitpod/issues/9821)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
