### PR TITLE
Add eu-west-3 as target region for custom AMI.

### DIFF
--- a/ami/copy-image.sh
+++ b/ami/copy-image.sh
@@ -13,6 +13,7 @@ TARGET_REGIONS=(
     us-west-1
     eu-west-1
     eu-west-2
+    eu-west-3
     eu-central-1
     us-east-1
     us-east-2


### PR DESCRIPTION
Add eu-west-3 as target region for custom AMI.

## Description
Make the custom AMI available on Paris region (eu-west-3)

## Related Issue(s)
N/A

## How to test

 check if AMI is publicly available in eu-west-3

## Release Notes
```
Make the custom AMI available on eu-west-3
```

## Documentation
https://github.com/gitpod-io/website/issues/2444