### PR TITLE
Update charts to make setup work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,10 @@ RUN apk add --no-cache \
 RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.12.0/yq_linux_amd64 -o /usr/local/bin/yq \
   && chmod +x /usr/local/bin/yq
 
-RUN curl -fsSL https://github.com/weaveworks/eksctl/releases/download/v0.75.0/eksctl_Linux_amd64.tar.gz | tar -xz -C /usr/local/bin
+RUN curl -fsSL https://github.com/weaveworks/eksctl/releases/download/v0.95.0/eksctl_Linux_amd64.tar.gz | tar -xz -C /usr/local/bin
 
 RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl
-
-RUN curl -fsSL https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.3/aws-iam-authenticator_0.5.3_linux_amd64 -o /usr/local/bin/aws-iam-authenticator \
-  && chmod +x /usr/local/bin/aws-iam-authenticator
 
 WORKDIR /gitpod
 

--- a/lib/charts/container-insights.ts
+++ b/lib/charts/container-insights.ts
@@ -29,7 +29,7 @@ export class ContainerInsights extends cdk.Construct {
             release: 'aws-for-fluent-bit',
             repository: 'https://aws.github.io/eks-charts',
             namespace,
-            version: '0.1.11',
+            version: '0.1.17',
             values: {
                 serviceAccount: {
                     create: false,

--- a/lib/charts/external-dns.ts
+++ b/lib/charts/external-dns.ts
@@ -43,7 +43,7 @@ export class ExternalDNS extends cdk.Construct {
             release: 'external-dns',
             repository: 'https://charts.bitnami.com/bitnami',
             namespace: EXTERNAL_DNS_NAMESPACE,
-            version: '5.5.0',
+            version: '6.5.3',
             values: {
                 podSecurityContext: {
                     fsGroup: 65534,

--- a/lib/charts/load-balancer.ts
+++ b/lib/charts/load-balancer.ts
@@ -14,7 +14,7 @@ export class AWSLoadBalancerController extends cdk.Construct {
             release: AWS_LOAD_BALANCER_CONTROLLER,
             repository: 'https://aws.github.io/eks-charts',
             namespace: 'kube-system',
-            version: '1.3.1',
+            version: '1.4.2',
             wait: true,
             values: {
                 replicaCount: 1,

--- a/lib/charts/metrics-server.ts
+++ b/lib/charts/metrics-server.ts
@@ -13,7 +13,7 @@ export class MetricsServer extends cdk.Construct {
             release: 'metrics-server',
             repository: 'https://charts.bitnami.com/bitnami',
             namespace: 'kube-system',
-            version: '5.10.10',
+            version: '5.10.14',
             wait: true,
             values: {
                 hostNetwork: true,

--- a/setup.sh
+++ b/setup.sh
@@ -91,7 +91,7 @@ function install() {
         # https://eksctl.io/usage/managing-nodegroups/
         eksctl create cluster --config-file "${EKSCTL_CONFIG}" --without-nodegroup --kubeconfig ${KUBECONFIG}
     else
-        eksctl utils write-kubeconfig --cluster "${CLUSTER_NAME}"
+        aws eks update-kubeconfig --name "${CLUSTER_NAME}"
     fi
 
     # Disable default AWS CNI provider.


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->

This PR updates the chat versions, and installs the relevant
aws cli's to match the latest kubernetes versions, thus making
the gitpod-eks-guide work.

This will be replaced with the [Gitpod Reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) in the near future.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update charts to make setup work
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
