### PR TITLE
Add deprecation notice for the EKS guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
- ## 📣 [IMPORTANT] This repo is being deprecated in favour of the [single cluster reference architecture](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) and the corresponding [terraform module](https://github.com/gitpod-io/gitpod/tree/main/install/infra/single-cluster/aws).
+ ## 📣 [IMPORTANT] This repo is being deprecated in favor of the [single cluster reference architecture](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) and the corresponding [Terraform config](https://github.com/gitpod-io/gitpod/tree/main/install/infra/single-cluster/aws).
 
 **What?** 
 
-We are deprecating this guide in favor of our [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) (specifically the [single cluster variant](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch)) that include both a guided walk-through and a `terraform` configuration.
+We are deprecating this guide in favor of our [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) (specifically the [single cluster variant](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch)) that include both a guided walk-through and a `Terraform` configuration.
 
 **Why?**
 
@@ -13,16 +13,16 @@ From your feedback, we’ve learned that the guide has several shortcomings:
 - One size fits all: it was not flexible enough if you wish to customize the infrastructure being created.
 - No incremental upgrades: If a version of a component changes, you’d have to recreate the infrastructure.
 
-Due to the feedback above we’ve decided to move to a more open and industry-standard way of speaking about the recommended infrastructure in the form of our new [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch). These are descriptions of what the ideal infrastructure for Gitpod looks like depending on your circumstances. They include both a text version as well as a terraform configuration that helps you create this infrastructure automatically - similarly to this guide. We believe these provide the following benefits: 
+Due to the feedback above we’ve decided to move to a more open and industry-standard way of speaking about the recommended infrastructure in the form of our new [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch). These are descriptions of what the ideal infrastructure for Gitpod looks like depending on your circumstances. They include both a text version as well as a Terraform configuration that helps you create this infrastructure automatically - similarly to this guide. We believe these provide the following benefits: 
 
-- They are based on a popular `Infrastructure as Code (IaC)` solution (`terraform`), which should facilitate maintenance for you (and us) via features such as incremental upgrades.
+- They are based on a popular `Infrastructure as Code (IaC)` solution (`Terraform`), which should facilitate maintenance for you (and us) via features such as incremental upgrades.
 - They are easier to parse, as they are configuration files rather than a script. This should make customizations easier.
-- They provide a detailed walkthrough for those that do not want to use terraform.
+- They provide a detailed walkthrough for those that do not want to use Terraform.
 - We already leverage these in our nightly testing to provide further validation and reliability of them when used to run Gitpod.
 
 **Impact?**
 
-Going forward, Gitpod will only officially support the [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch). If you can, we would advise you to switch towards using these - this would require you to recreate your infrastructure using the new terraform configurations or guide. Staying on infrastructure created by this guide *should* work going forward, however, we cannot guarantee this in perpetuity.
+Going forward, Gitpod will only officially support the [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch). If you can, we would advise you to switch towards using these - this would require you to recreate your infrastructure using the new Terraform configurations or guide. Staying on infrastructure created by this guide *should* work going forward, however, we cannot guarantee this in perpetuity.
 
 —> The Reference Architectures are still in `beta` or `alpha` while we gather more feedback. Please do reach out to us on Discord or via [support](https://www.gitpod.io/support) with any problems or feedback.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
-## 📣 [IMPORTANT] This repo is being deprecated in favor of [Gitpod reference architecture](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) and the corresponding [terraform module](https://github.com/gitpod-io/gitpod/tree/main/install/infra/single-cluster/aws). 
 
-We have decided to deprecate this module after serving its purpose for almost over a year. We are deeply sorry for any inconvenience this might have caused, but we believe this shift adds a lot of value and ultimately makes setting up Gitpod a much smoother experience.
+ ## 📣 [IMPORTANT] This repo is being deprecated in favour of the [single cluster reference architecture](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) and the corresponding [terraform module](https://github.com/gitpod-io/gitpod/tree/main/install/infra/single-cluster/aws).
 
-Overtime, the number of issues the users of this guide run into has risen significantly, and the maintenance of the same has proven to be challenging for us. Moreover, the setup this guide offers is not flexible enough if the user wishes to customise the infrastructure being created. The maintenance of the created infrastructure can be difficult since the guide doesn't provide any continued support.
+**What?** 
 
-Hence, after thorough consideration, we have decided to move to a more `Infrastructure as Code(IaC)` solution by providing `terraform` modules that can setup and provision an EKS Kubernetes Cluster for installing Gitpod. We expect moving to such a popular community solution would offer much more flexibility and support for the folks trying to setup Gitpod.
+We are deprecating this guide in favor of our [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) (specifically the [single cluster variant](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch)) that include both a guided walk-through and a `terraform` configuration.
 
-As Gitpod has continued to offer a frictionless development experience, we expect this new solution will provide a frictionless setup experience for the users. We are very excited about this new phase of Gitpod setup and maintenance. 🤩
+**Why?**
 
-# Running Gitpod in [Amazon EKS](https://aws.amazon.com/en/eks/)
+From your feedback, we’ve learned that the guide has several shortcomings:
+
+- It is not obvious what the guide does: it is more a black box than a sensible starting point for creating the infrastructure that works for you.
+- One size fits all: it was not flexible enough if you wish to customize the infrastructure being created.
+- No incremental upgrades: If a version of a component changes, you’d have to recreate the infrastructure.
+
+Due to the feedback above we’ve decided to move to a more open and industry-standard way of speaking about the recommended infrastructure in the form of our new [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch). These are descriptions of what the ideal infrastructure for Gitpod looks like depending on your circumstances. They include both a text version as well as a terraform configuration that helps you create this infrastructure automatically - similarly to this guide. We believe these provide the following benefits: 
+
+- They are based on a popular `Infrastructure as Code (IaC)` solution (`terraform`), which should facilitate maintenance for you (and us) via features such as incremental upgrades.
+- They are easier to parse, as they are configuration files rather than a script. This should make customizations easier.
+- They provide a detailed walkthrough for those that do not want to use terraform.
+- We already leverage these in our nightly testing to provide further validation and reliability of them when used to run Gitpod.
+
+**Impact?**
+
+Going forward, Gitpod will only officially support the [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch). If you can, we would advise you to switch towards using these - this would require you to recreate your infrastructure using the new terraform configurations or guide. Staying on infrastructure created by this guide *should* work going forward, however, we cannot guarantee this in perpetuity.
+
+—> The Reference Architectures are still in `beta` or `alpha` while we gather more feedback. Please do reach out to us on Discord or via [support](https://www.gitpod.io/support) with any problems or feedback.
+
+------
+## Running Gitpod in [Amazon EKS](https://aws.amazon.com/en/eks/)
 
 > **IMPORTANT** This guide exists as a simple and reliable way of creating required AWS infrastructure. It
 > is not designed to cater for every situation. If you find that it does not meet your exact needs,
@@ -17,7 +36,7 @@ As Gitpod has continued to offer a frictionless development experience, we expec
 This guide exists as a simple and reliable way of creating an environment in AWS (EKS) that [Gitpod can
 be installed](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) into. Upon completion, it will print the config for the resources created (including passwords) and create the necessary credential files that will allow you to connect the components created to your Gitpod instance during the [next installation step](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod).
 
-## Provision an EKS cluster
+### Provision an EKS cluster
 
 Before starting the installation process, you need:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **What?** 
 
-We are deprecating this guide in favor of our [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) (specifically the [single cluster variant](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch)) that include both a guided walk-through and a `Terraform` configuration.
+We are deprecating this guide in favor of our [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture) (specifically the [single cluster variant](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch)) that include both a guided walk-through and a `Terraform` configuration.
 
 **Why?**
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## 📣 [IMPORTANT] This repo is being deprecated in favor of [Gitpod reference architecture](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) and the corresponding [terraform module](https://github.com/gitpod-io/gitpod/tree/main/install/infra/single-cluster/aws). 
+
+We have decided to deprecate this module after serving its purpose for almost over a year. We are deeply sorry for any inconvenience this might have caused, but we believe this shift adds a lot of value and ultimately makes setting up Gitpod a much smoother experience.
+
+Overtime, the number of issues the users of this guide run into has risen significantly, and the maintenance of the same has proven to be challenging for us. Moreover, the setup this guide offers is not flexible enough if the user wishes to customise the infrastructure being created. The maintenance of the created infrastructure can be difficult since the guide doesn't provide any continued support.
+
+Hence, after thorough consideration, we have decided to move to a more `Infrastructure as Code(IaC)` solution by providing `terraform` modules that can setup and provision an EKS Kubernetes Cluster for installing Gitpod. We expect moving to such a popular community solution would offer much more flexibility and support for the folks trying to setup Gitpod.
+
+As Gitpod has continued to offer a frictionless development experience, we expect this new solution will provide a frictionless setup experience for the users. We are very excited about this new phase of Gitpod setup and maintenance. 🤩
+
 # Running Gitpod in [Amazon EKS](https://aws.amazon.com/en/eks/)
 
 > **IMPORTANT** This guide exists as a simple and reliable way of creating required AWS infrastructure. It


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a small deprecation notice to the README. We can add a `Why` section under the deprecation notice if necessary. Some of the tasks left to do still to be done by folks with admin access :
- [ ] Close the issue and pull requests sections in the repo
- [ ] Add a `[Deprecated]` prefix to the `About` of the repo
- [x] Add `Why` to the deprecated notice

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Deprecating the `gitpod-eks-guide` in favor of reference architecture and terraform modules
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
