### PR TITLE
Disable npm lifecycle scripts for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ WORKDIR /gitpod
 
 COPY . /gitpod
 
-RUN yarn --pure-lockfile --non-interactive \
+RUN yarn --pure-lockfile --non-interactive --ignore-scripts \
   && rm -rf /usr/local/share/.cache/yarn
 
-RUN npm install -g aws-cdk ts-node
+RUN npm install -g --ignore-scripts aws-cdk ts-node
 
 ENTRYPOINT ["/gitpod/setup.sh"]


### PR DESCRIPTION
Add `--ignore-scripts` flag to yarn and npm install commands in Dockerfile to prevent execution of potentially malicious scripts during package installation.

Related to [PDE-128](https://linear.app/ona-team/issue/PDE-128/parent-issue-disabling-npm-lifecycle-scripts)